### PR TITLE
Set rpath when linking the cli

### DIFF
--- a/exe/compile
+++ b/exe/compile
@@ -2,6 +2,8 @@
 
 gcc="gcc -O3"
 
+prefix=$1
+
 exit_on_error() {
   $* || exit 1
 }
@@ -16,7 +18,8 @@ compile_libscrypt() {
 }
 
 compile_scrypt_kdf() {
-  exit_on_error $gcc source/cli.c -o temp/scrypt-kdf --std=c11 -L./temp -lscrypt -lm
+  ld_flags="-Wl,-rpath,$prefix/usr/lib"
+  exit_on_error $gcc source/cli.c $ld_flags -o temp/scrypt-kdf --std=c11 -L./temp -lscrypt -lm
 }
 
 mkdir -p temp

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ The provided compile script uses shell and "GCC", and the code depends on the C 
 
 ## Compilation and installation
 ```
-./exe/compile && ./exe/install [target-prefix]
+./exe/compile [target-prefix] && ./exe/install [target-prefix]
 ```
 
 * Installs a library under {target-prefix}/usr/lib/libscrypt.so


### PR DESCRIPTION
I had to do this in order to run the cli in a prefixed-installation (on Linux). I hope this will help other users as well.